### PR TITLE
修改了c语言注释的分割方法

### DIFF
--- a/plugin_stm32.py
+++ b/plugin_stm32.py
@@ -234,7 +234,7 @@ class Plugin(object):
             # hal_crc index
             index = [i for i in range(len(lines))
                      if "HAL_CRC_MODULE_ENABLED" in lines[i]][0]
-            new_line = " ".join(lines[index].split()[1:-1])
+            new_line = " ".join(lines[index].split('*')[1:-1])
             new_line += "\n"
 
             if "*" in lines[index]:


### PR DESCRIPTION
之前的分割方法因为rt-thread studio生成的h7与l4工程的差异会导致生成的stm32L476工程编译失败，将以空格分割修改为了以*分割，经测试，修改后h7和l4工程都没有问题